### PR TITLE
fix: Handle None starting timestamp (NEKT-3192)

### DIFF
--- a/tap_jira_nekt/streams/issues.py
+++ b/tap_jira_nekt/streams/issues.py
@@ -638,7 +638,9 @@ class IssueStream(JiraStream):
             params["sort"] = "asc"
             params["order_by"] = self.replication_key
 
-        jql.append(f"updated>='{self.get_starting_timestamp(context).strftime('%Y/%m/%d %H:%M')}'")
+        starting_timestamp = self.get_starting_timestamp(context)
+        if starting_timestamp:
+            jql.append(f"updated>='{starting_timestamp.strftime('%Y/%m/%d %H:%M')}'")
 
         # Add project filter if configured
         project_keys = self.config.get("project_keys")


### PR DESCRIPTION
Closes NEKT-3192

## Changes
- Guard against `get_starting_timestamp(context)` returning `None` in the issues stream JQL builder
- When no start date is configured, the `updated>=` filter is simply omitted instead of crashing with `AttributeError: 'NoneType' object has no attribute 'strftime'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)